### PR TITLE
Updates to wavsurfer_app: Conducting FFT on audio signal and binning frequencies

### DIFF
--- a/wavsurfer_app/JuceLibraryCode/JuceHeader.h
+++ b/wavsurfer_app/JuceLibraryCode/JuceHeader.h
@@ -15,8 +15,10 @@
 
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_core/juce_core.h>
 #include <juce_data_structures/juce_data_structures.h>
+#include <juce_dsp/juce_dsp.h>
 #include <juce_events/juce_events.h>
 #include <juce_graphics/juce_graphics.h>
 #include <juce_gui_basics/juce_gui_basics.h>

--- a/wavsurfer_app/Source/MainComponent.cpp
+++ b/wavsurfer_app/Source/MainComponent.cpp
@@ -1,20 +1,204 @@
 #include "MainComponent.h"
+#include <chrono>
 
 //==============================================================================
 MainComponent::MainComponent()
 {
+     
+    // fill in fft windowing function
+    juce::dsp::WindowingFunction<float>::fillWindowingTables(windowingFunction.data(), fftSize, juce::dsp::WindowingFunction<float>::hann);
+    
+    // manually (for now) computing low, mid, and high frequency bands
+    // TODO: Define freq range and set these based off range/numbands?
+    bandStartBin = std::vector<int>(numBands, 0);
+    bandEndBin = std::vector<int>(numBands, 0);
+    bandStartBin[0] = static_cast<int>(std::ceil(lowFreq / frequencyResolution));
+    bandEndBin[0] = static_cast<int>(std::floor(midFreq / frequencyResolution));
+    bandStartBin[1] = bandEndBin[0];
+    bandEndBin[1] = static_cast<int>(std::floor(highFreq / frequencyResolution));
+    bandStartBin[2] = bandEndBin[1];
+    bandEndBin[2] = fftSize / 2; // nyquist limit
+
+    // setting up dqVecs: a vector containing a vector per channel which contains a deque per frequency band
+    for (int i = 0; i < supportedChannels; ++i)
+    {
+        dqVecs.push_back(std::vector<std::deque<float>>());
+        // set up second level (deque at each vector component)
+        for (int j = 0; j < numBands; ++j)
+        {
+            dqVecs[i].push_back(std::deque<float>());
+        }
+    }
+
+    // audio device setup
     audioDeviceManager.initialise(2, 0, nullptr, true, "Null Audio Device");
     audioDeviceManager.addAudioCallback(this);
-    startTimerHz(60);
+    
+    // page size setup
     setSize (1920, 1080);
     
-    auto surferBinary = BinaryData::surfer_png;
-    auto surferBinarySize = BinaryData::surfer_pngSize;
-    juce::MemoryInputStream stream(surferBinary, surferBinarySize, false);
-    juce::Image surferFullSize = juce::ImageFileFormat::loadFrom(stream);
+    // repaint callback setup
+    startTimerHz(60);
+    
+    // TODO: Add back in surfer image setup if decide to add image back in
+    //    auto surferBinary = BinaryData::surfer_png;
+    //    auto surferBinarySize = BinaryData::surfer_pngSize;
+    //    juce::MemoryInputStream stream(surferBinary, surferBinarySize, false);
+    //    juce::Image surferFullSize = juce::ImageFileFormat::loadFrom(stream);
+    
+    
+    // Set up background image (optional)
+    /*
+    auto backgroundBinary = BinaryData::IMG_9897_jpeg;
+    auto backgroundBinarySize = BinaryData::IMG_9897_jpegSize;
+    juce::MemoryInputStream stream(backgroundBinary, backgroundBinarySize, false);
+    juce::Image backgroundImageRaw = juce::ImageFileFormat::loadFrom(stream);
+    backgroundImage = backgroundImageRaw.rescaled(1920, 1080, juce::Graphics::highResamplingQuality);
+    */
+}
 
-    surferImage = surferFullSize.rescaled(100, 100, juce::Graphics::highResamplingQuality);
 
+MainComponent::~MainComponent()
+{
+    audioDeviceManager.removeAudioCallback(this);
+}
+
+
+//==============================================================================
+void MainComponent::paint (juce::Graphics& g)
+{
+    int width = getWidth();
+    int height = getHeight();
+    g.fillAll(juce::Colours::black);
+    g.drawImage (backgroundImage, getLocalBounds ().toFloat ());
+
+    float heightMultiplier = 1;
+
+    // Paint every channel's frequency bins
+    for (int i = 0; i < supportedChannels; ++i) // channels
+    {
+        for (int j = 0; j < numBands; ++j) // freq bands
+        {
+            // rough height multiplier to account of low freq rms being disproportionately larger
+            heightMultiplier = 1.0/(numBands + 1 - j);
+            
+            
+            juce::Path rmsPath;
+            for (int k = 0; k < dqVecs[i][j].size(); ++k) // rms history deque elements
+            {
+                float x = (float)k / (float)maxHistory * (float)width;
+                float y = juce::jmap(dqVecs[i][j][k]*heightMultiplier, 0.0f, 1.0f, (float)height, 0.0f);
+                if (k == 0)
+                {
+                    rmsPath.startNewSubPath(x, y);
+                }
+                else
+                {
+                    rmsPath.lineTo(x, y);
+                }
+            }
+
+            // extend path to bottom-right corner
+            float lastX = (float) dqVecs[i][j].size() / (float) maxHistory * (float) width;
+            rmsPath.lineTo(lastX, height);
+
+            // draw line to bottom-left corner
+            rmsPath.lineTo(0, height);
+            rmsPath.closeSubPath();
+            
+            g.setColour(juce::Colours::purple.withAlpha(0.3f));
+            g.fillPath(rmsPath);
+            g.setColour(juce::Colours::purple);
+            g.strokePath(rmsPath, juce::PathStrokeType(2.0f));
+
+        }
+    }
+
+    // TODO: Decide whether to add back in surfer (below)
+    /*
+     if (!surferImage.isNull()) {
+        g.drawImageAt(surferImage, halfWidth, halfHeight);
+     */
+}
+
+
+void MainComponent::resized()
+{
+    // called when main component resized
+}
+
+
+// at 512 samples per second and 44.1khz sample rate, callback should be called ~86 times/sec, giving this function a theoretical upper limit of 11.63ms to maintain real time constraints.
+// currently runs at ~.05ms, so there is definitely room for more processing
+void MainComponent::audioDeviceIOCallbackWithContext (const float *const *inputChannelData, int numInputChannels, float *const *outputChannelData, int numOutputChannels, int numSamples, const juce::AudioIODeviceCallbackContext &context)
+{
+    auto start = std::chrono::high_resolution_clock::now();
+    callbackCount++;
+    
+    float fftData[2 * fftSize] = {0};
+
+    for (int inputChannel = 0; inputChannel < numInputChannels; ++inputChannel)
+    {
+        if(inputChannelData[inputChannel] == nullptr)
+        {
+            continue;
+        }
+
+        // windowing
+        for(int i = 0; i < fftSize; ++i)
+        {
+            fftData[i] = inputChannelData[inputChannel][i] * windowingFunction[i];
+        }
+        fft->performFrequencyOnlyForwardTransform(fftData);
+
+        // calculating rms for each freq band
+        for(int band = 0; band < numBands; ++band)
+        {
+            float sumOfSquares = 0.0f;
+            int startBin = bandStartBin[band];
+            int endBin = bandEndBin[band];
+
+            for(int bin = startBin; bin < endBin; ++bin)
+            {
+                float magnitude = fftData[bin];
+                sumOfSquares += magnitude * magnitude;
+            }
+
+            if (inputChannel < supportedChannels)
+            {
+                if (dqVecs[inputChannel][band].size() >= maxHistory)
+                {
+                    dqVecs[inputChannel][band].pop_front();
+                }
+                dqVecs[inputChannel][band].push_back(std::sqrt(sumOfSquares / (endBin - startBin)));
+            }
+        }
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::milli> ms_double = end - start;
+    std::cout<< "Audio callback took approx " << ms_double.count() << "ms\n";
+
+}
+
+
+void MainComponent::timerCallback() {
+    // time calculations on callback
+    timerCalls++;
+    if(timerCalls == 60)
+    {
+        printf("Callback was called %d times in the past second\n", callbackCount);
+        callbackCount = 0;
+        timerCalls = 0;
+    }
+    
+    // repainting main window
+    repaint();
+}
+
+
+// helper fxn to pritn info about the audio device
+void printAudioDeviceInfo(juce::AudioDeviceManager & audioDeviceManager) {
     auto* currentDevice = audioDeviceManager.getCurrentAudioDevice();
     if (currentDevice != nullptr)
     {
@@ -30,146 +214,4 @@ MainComponent::MainComponent()
         auto bitDepth = currentDevice->getCurrentBitDepth();
         juce::Logger::writeToLog("Bit Depth: " + juce::String(bitDepth));
     }
-
-    
-
-}
-
-MainComponent::~MainComponent()
-{
-    audioDeviceManager.removeAudioCallback (this);
-}
-
-//==============================================================================
-void MainComponent::paint (juce::Graphics& g)
-{
-    int width = getWidth();
-    int height = getHeight();
-    g.fillAll(juce::Colours::black);
-    
-    // rms path for channel 1
-    juce::Path rmsPath;
-    for (int i = 0; i < rmsHistory.size(); ++i)
-    {
-        float x = (float)i / (float)maxHistory * (float)width;
-        float y = juce::jmap(rmsHistory[i]*10, 0.0f, 1.0f, (float)height, 0.0f);
-        
-        if (i == 0)
-        {
-            rmsPath.startNewSubPath(x, y);
-        }
-        else
-        {
-            rmsPath.lineTo(x, y);
-        }
-    }
-
-    // extend path to bottom-right corner
-    float lastX = (float) rmsHistory.size() / (float) maxHistory * (float) width;
-    rmsPath.lineTo(lastX, height);
-    
-    // draw line to bottom-left corner
-    rmsPath.lineTo(0, height);
-    rmsPath.closeSubPath();
-    
-    // fill path
-    g.setColour(juce::Colours::purple.withAlpha(0.3f));
-    g.fillPath(rmsPath);
-    
-    // set line color
-    g.setColour(juce::Colours::purple);
-    g.strokePath(rmsPath, juce::PathStrokeType(2.0f));
-    
-    // draw surfer halfway through line
-    int halfWidth = static_cast<int>((float)rmsHistory.size()/2 / (float)maxHistory * (float)width);
-    int halfHeight = juce::jmap(std::max(rmsHistory[rmsHistory.size()/2], rmsHistory2[rmsHistory.size()/2])*10, 0.0f, 1.0f, (float)height, 0.0f) - 80;
-
-    if (!surferImage.isNull()) {
-        g.drawImageAt(surferImage, halfWidth, halfHeight);
-    }
-    
-    
-
-    // rms path for channel 2
-    juce::Path rmsPath2;
-    for (int i = 0; i < rmsHistory.size(); ++i)
-    {
-        float x = (float)i / (float)maxHistory * (float)width;
-        float y = juce::jmap(rmsHistory2[i]*10, 0.0f, 1.0f, (float)height, 0.0f);
-        
-        if (i == 0)
-        {
-            rmsPath2.startNewSubPath(x, y);
-        }
-        else
-        {
-            rmsPath2.lineTo(x, y);
-        }
-    }
-
-    // extend path to bottom-right corner
-    rmsPath2.lineTo(lastX, height);
-    
-    // draw line to bottom-left corner
-    rmsPath2.lineTo(0, height);
-    rmsPath2.closeSubPath();
-    
-    // fill path
-    g.setColour(juce::Colours::blue.withAlpha(0.3f));
-    g.fillPath(rmsPath2);
-    
-    // set line color
-    g.setColour(juce::Colours::blue);
-    g.strokePath(rmsPath2, juce::PathStrokeType(2.0f));
-    
-
-    
-
-}
-
-void MainComponent::resized()
-{
-    // called when MC resized. update child component positions here
-}
-
-void MainComponent::audioDeviceIOCallbackWithContext (const float *const *inputChannelData, int numInputChannels, float *const *outputChannelData, int numOutputChannels, int numSamples, const juce::AudioIODeviceCallbackContext &context)
-{
-    for (int inputChannel = 0; inputChannel < numInputChannels; ++inputChannel)
-    {
-        if(inputChannelData[inputChannel]!= nullptr)
-        {
-            float sumOfSquares = 0.0f;
-            for(int sample = 0; sample < numSamples; ++sample)
-            {
-                float sampleVal =inputChannelData[inputChannel][sample];
-                sumOfSquares += sampleVal * sampleVal;
-                //printf("Input[%d][%d] = %f\n", inputChannel, sample, inputChannelData[inputChannel][sample]);
-            }
-            
-            rms[inputChannel]  = std::sqrt(sumOfSquares/numSamples);
-            printf("RMS for channel %d is %f\n", inputChannel, rms[inputChannel]);
-            smoothedRms[inputChannel] = ((1.0f - smoothingFactor) * smoothedRms[inputChannel]) + (smoothingFactor * rms[inputChannel]);
-            if(inputChannel == 0)
-            {
-                if (rmsHistory.size() >= maxHistory)
-                {
-                    rmsHistory.pop_front();
-                }
-                if (rmsHistory2.size() >= maxHistory)
-                {
-                    rmsHistory2.pop_front();
-                }
-                rmsHistory.push_back(smoothedRms[0]);
-                rmsHistory2.push_back(smoothedRms[1]);
-            }
-
-
-            
-        }
-    }
-}
-
-
-void MainComponent::timerCallback() {
-    repaint();
 }

--- a/wavsurfer_app/Source/MainComponent.h
+++ b/wavsurfer_app/Source/MainComponent.h
@@ -2,12 +2,9 @@
 
 #include <JuceHeader.h>
 #include <vector>
+#include <juce_dsp/juce_dsp.h>
 
 //==============================================================================
-/*
-    This component lives inside our window, and this is where you should put all
-    your controls and content.
-*/
 class MainComponent  : public juce::Component, public juce::AudioIODeviceCallback, public juce::Timer
 {
 public:
@@ -28,18 +25,39 @@ public:
 private:
     //==============================================================================
     juce::AudioDeviceManager audioDeviceManager;
-    std::vector<float> rms {0.0f, 0.0f};
-    std::vector<float> smoothedRms {0.0f, 0.0f};
-    //float smoothingFactor = 0.005;
-    //float smoothingFactor = 0.01;
-    float smoothingFactor = 0.1; //0 high smoothing, 1 low smoothing
-    std::deque<float> rmsHistory;
-    std::deque<float> rmsHistory2;
-    const int maxHistory = 100;
-    juce::Image surferImage;
-    
-    
 
+    int supportedChannels = 2;
+    static constexpr int numBands = 3;
+    const int sampleRate = 44100;
+    static constexpr int fftSize = 512; // equal to numsamples
+
+    // FFT related components
+    std::array<float, fftSize> windowingFunction;
+    int order = static_cast<int>(std::log2(fftSize));
+    std::unique_ptr<juce::dsp::FFT> fft = std::make_unique<juce::dsp::FFT>(order);
+    std::vector<int> bandStartBin;
+    std::vector<int> bandEndBin;
+    const float frequencyResolution = static_cast<float>(sampleRate) / fftSize;
+    // TODO: set freq range and calculate these based off range/numbands instead
+    const float lowFreq = 20.0f;
+    const float midFreq = 250.0f;
+    const float highFreq = 4000.0f;
+    const float nyquist = sampleRate / 2.0f;
+    
+    
+    // Vector containing vector per channel containing deque per freq band to store RMS for painting
+    std::vector<std::vector<std::deque<float>>> dqVecs;
+    const int maxHistory = 100; // max elements in each deque
+    
+    
+    // for verifying audiocallback calls per second ~= 44100/512
+    int callbackCount = 0;
+    int timerCalls = 0;
+    
+    
+    // image related
+    juce::Image surferImage;
+    juce::Image backgroundImage;
 
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainComponent)

--- a/wavsurfer_app/wavsurfer.jucer
+++ b/wavsurfer_app/wavsurfer.jucer
@@ -14,8 +14,10 @@
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="juce_audio_devices" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_audio_formats" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="juce_core" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="juce_data_structures" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
+    <MODULE id="juce_dsp" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="juce_events" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="juce_graphics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
     <MODULE id="juce_gui_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="1"/>
@@ -35,6 +37,8 @@
         <MODULEPATH id="juce_events" path="../../JUCE/modules"/>
         <MODULEPATH id="juce_graphics" path="../../JUCE/modules"/>
         <MODULEPATH id="juce_gui_basics" path="../../JUCE/modules"/>
+        <MODULEPATH id="juce_dsp" path="../../JUCE/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="../../JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
   </EXPORTFORMATS>


### PR DESCRIPTION
Time to make wavsurfer_app a little less elementary

Calculating FFT of audio signal for each channel, binning into low/mid/high freq bins for each channel, then calculating RMS of each bin and storing into deque

Instead of RMS of entire signal being calculated, RMS of frequency bins is calculated instead.

Currently 3 frequency bins (low, mid, high), and 2 channels -> 6 deques, 6 lines displayed on wavsurfer_app now

Next step is adding smoothing to each rms deque so that its less jarring to look at