### PR TITLE
implementing exponential smoothing and tuning height multiplier

### DIFF
--- a/wavsurfer_app/Source/MainComponent.cpp
+++ b/wavsurfer_app/Source/MainComponent.cpp
@@ -80,7 +80,6 @@ void MainComponent::paint (juce::Graphics& g)
         for (int j = 0; j < numBands; ++j) // freq bands
         {
             // rough height multiplier to account of low freq rms being disproportionately larger
-            //heightMultiplier = 2 * (j + 1)*(j + 1) / (numBands); //1.0/(numBands + 7 - 2*j); //TODO: generalize to any number of bands
             heightMultiplier = 3 * pow(5.0 / 4.0, j) / (5 * numBands);
             
             juce::Path rmsPath;

--- a/wavsurfer_app/Source/MainComponent.h
+++ b/wavsurfer_app/Source/MainComponent.h
@@ -44,10 +44,12 @@ private:
     const float highFreq = 4000.0f;
     const float nyquist = sampleRate / 2.0f;
     
+    // used for exponential smoothing of displayed signal
+    const float smoothingFactor = .15;
     
-    // Vector containing vector per channel containing deque per freq band to store RMS for painting
+    // vector containing vector per channel containing deque per freq band to store RMS for painting
     std::vector<std::vector<std::deque<float>>> dqVecs;
-    const int maxHistory = 100; // max elements in each deque
+    const int maxHistory = 500; // max elements in each deque
     
     
     // for verifying audiocallback calls per second ~= 44100/512


### PR DESCRIPTION
adding exponential smoothing to the displayed RMS signals, roughly newSmoothedValue = ((1 - smoothingFactor) * oldSmoothedValue) + (smoothingFactor * newRawValue)

**this means the visualizer is less jarring and a little smoother now**

also messed with height multiplier. I need to dig into it and think of one that generalizes better but 
heightMultiplier = 3 * pow(5.0 / 4.0, j) / (5 * numBands);
where j = 0 means low freq, j = 1 means mid freq, j = 2 means high freq
1/5 coefficient: main goal is to significantly reduce the height of low freq
1/numbands coefficient: naive attempt to generalize for any numbands
pow(5.0 / 4.0, j): exponential growth for higher frequencies
**need to do some research as to how much rms falls for higher freqs**


